### PR TITLE
changes to answer Tom LeCompte's question

### DIFF
--- a/r3.md
+++ b/r3.md
@@ -6,10 +6,10 @@ Status of Using HPC and Commercial Clouds
 We have successfully demonstrated the multi-threaded execution of CMS’
 physics software on Intel Knights Landing (KNL) CPU architectures, by
 running the reconstruction algorithms on input data and producing
-analysis output data.  Comparing cost efficiency, dollar-for-dollar the
-total physics throughput is currently five times lower for KNL-based
-hosts versus a traditional Intel Xeon host. 
-
+analysis output data.  Comparing event throughput per thread, the KNL-based
+host has 5x less throughput than a 2010-era Xeon host.  A cost extrapolation
+suggests that, dollar-for-dollar, the KNL platform is far less efficient than a
+traditional Intel Xeon host.
 
 CMS’ physics application demonstrates near-linear scaling up to 64
 threads; we fully utilize a current KNL host by running 4 multi-threaded


### PR DESCRIPTION
===========

Question:

On Page 4, you discuss the relative cost-effectiveness of KNL.  What is the relative performance difference?  That is, how many Spec06s does a KNL node provide (as opposed to what it is theoretically capable of providing)
On page 13 you suggest it is a factor of 5, but this doesn't mesh with the factor of 5 in cost-effectiveness unless the chip costs are the same, which they are not.

Answer:

On page 4, we mistakenly merged two statements together. We will replace:

"Comparing cost efficiency, dollar-for-dollar the total physics throughput is currently five times lower for KNL-based hosts versus a traditional Intel Xeon host."

with 

"Comparing event throughput per thread, the KNL-based host has 5x less throughput than a 2010-era Xeon host.  A cost extrapolation suggests that, dollar-for-dollar, the KNL platform is far less efficient than a traditional Intel Xeon host."

The comparison we are referring to is based on 12-thread CMS applications on a dual Xeon X5650 @2.67GHz (Westmere EP) with 2x6x2=24 hardware threads compared to the same 12-thread application on an Intel KNL developer node from 2016, which resulted in ~5 lower event throughput on KNL. We are planning to repeat the comparison using a recent KNL host with a 2016-era traditional Xeon machine. 

===========
